### PR TITLE
Fix bugs when casting to a compound type.

### DIFF
--- a/fixtures/expressions/chancast/chan.go.txt
+++ b/fixtures/expressions/chancast/chan.go.txt
@@ -1,0 +1,1 @@
+chan int(foo)

--- a/fixtures/expressions/chancast/chan.json
+++ b/fixtures/expressions/chancast/chan.json
@@ -1,0 +1,25 @@
+{
+    "type": "cast",
+    "kind": "expression",
+    "coerced-to": {
+        "kind": "type",
+        "type": "chan",
+        "direction": "both",
+        "value": {
+            "kind": "type",
+            "type": "identifier",
+            "value": {
+                "kind": "ident",
+                "value": "int"
+            }
+        }
+    },
+    "target": {
+        "kind": "expression",
+        "type": "identifier",
+        "value": {
+            "kind": "ident",
+            "value": "foo"
+        }
+    }
+}

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -83,6 +83,11 @@ func TestExpressionFixtures(t *testing.T) {
 			"fixtures/expressions/doublequalifier/double.go.txt",
 			"fixtures/expressions/doublequalifier/double.json",
 		},
+		Fixture{
+			"cast to chan",
+			"fixtures/expressions/chancast/chan.go.txt",
+			"fixtures/expressions/chancast/chan.json",
+		},
 	}
 
 	for _, fix := range fixtures {


### PR DESCRIPTION
Previously, `chan int(foo)` attempted to parse the left-hand side
as purely an expression. We now try to treat it as a type, and only
treat it as a function call if we yield a pure identifier.