### PR TITLE
Fix crash in untyped top-level declarations.

### DIFF
--- a/fixtures/packages/untypedvar/untyped.go
+++ b/fixtures/packages/untypedvar/untyped.go
@@ -1,0 +1,3 @@
+package p
+
+var a = 1

--- a/fixtures/packages/untypedvar/untyped.json
+++ b/fixtures/packages/untypedvar/untyped.json
@@ -1,0 +1,30 @@
+{
+    "comments": null,
+    "kind": "file",
+    "name": {
+        "kind": "ident",
+        "value": "p"
+    },
+    "imports": [],
+    "declarations": [
+        {
+            "comments": null,
+            "declared-type": null,
+            "kind": "decl",
+            "names": [
+                {
+                    "kind": "ident",
+                    "value": "a"
+                }
+            ],
+            "type": "var",
+            "values": [
+                {
+                    "kind": "literal",
+                    "type": "INT",
+                    "value": "1"
+                }
+            ]
+        }
+    ]
+}

--- a/goblin.go
+++ b/goblin.go
@@ -483,7 +483,7 @@ func DumpValue(kind string, spec *ast.ValueSpec, fset *token.FileSet) map[string
 		"kind":          "decl",
 		"type":          kind,
 		"names":         processedNames,
-		"declared-type": DumpExprAsType(spec.Type, fset),
+		"declared-type": AttemptExprAsType(spec.Type, fset),
 		"values":        processedValues,
 		"comments":      DumpCommentGroup(spec.Doc, fset),
 	}
@@ -516,11 +516,18 @@ func DumpGenDecl(decl *ast.GenDecl, fset *token.FileSet) interface{} {
 		panic("Unrecognized token " + decl.Tok.String() + " in GenDecl at " + pos)
 	}
 
-	// HIGHLY MORALLY DUBIOUS HACK: we seem to be getting spurious arrays in top-level var
-	// declarations. until I can track these down, this hack has to persist
-	if len(results) == 1 {
-		return results[0]
+	// Imports are the only GenDecl that contains multiple specs. In all other cases,
+	// there will be only one item contained, so for ease of parsing we just return the
+	// bare item.
+	if decl.Tok != token.IMPORT {
+		if len(results) == 1 {
+			return results[0]
+		} else {
+			pos := fset.PositionFor(decl.Pos(), true).String()
+			panic("Unexpected multiple results in GenDecl node at " + pos)
+		}
 	}
+
 	return results
 }
 

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -44,6 +44,10 @@ func TestPackageFixtures(t *testing.T) {
 			"fixtures/packages/simpletypealias/simpletypealias.go",
 			"fixtures/packages/simpletypealias/simpletypealias.json",
 		},
+		Fixture{"untyped top-level variable",
+			"fixtures/packages/untypedvar/untyped.go",
+			"fixtures/packages/untypedvar/untyped.json",
+		},
 	}
 
 	for _, fix := range fixtures {


### PR DESCRIPTION
Declarations can be untyped, so use AttemptExprAsType instead of Dump.
Bumps coverage to 45%. Also clarifies the purpose of what I thought was 
a morally dubious hack but is actually perfectly reasonable.