### PR TITLE
Rewrite DumpType() into specific DumpTypeAlias() [#14]

### DIFF
--- a/fixtures/packages/simpletypealias/simpletypealias.go
+++ b/fixtures/packages/simpletypealias/simpletypealias.go
@@ -1,0 +1,7 @@
+package main
+
+type MyArray [100]int
+
+func main() {
+
+}

--- a/fixtures/packages/simpletypealias/simpletypealias.json
+++ b/fixtures/packages/simpletypealias/simpletypealias.json
@@ -1,0 +1,48 @@
+{
+    "comments": null,
+    "declarations": [
+        {
+            "comments": null,
+            "kind": "decl",
+            "name": {
+                "kind": "ident",
+                "value": "MyArray"
+            },
+            "type": "type-alias",
+            "value": {
+                "element": {
+                    "kind": "type",
+                    "type": "identifier",
+                    "value": {
+                        "kind": "ident",
+                        "value": "int"
+                    }
+                },
+                "kind": "type",
+                "length": {
+                    "kind": "literal",
+                    "type": "INT",
+                    "value": "100"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "body": [],
+            "kind": "decl",
+            "name": {
+                "kind": "ident",
+                "value": "main"
+            },
+            "params": [],
+            "results": null,
+            "type": "function"
+        }
+    ],
+    "imports": [],
+    "kind": "file",
+    "name": {
+        "kind": "ident",
+        "value": "main"
+    }
+}

--- a/goblin.go
+++ b/goblin.go
@@ -394,54 +394,12 @@ func DumpCommentGroup(g *ast.CommentGroup, fset *token.FileSet) []string {
 	return result
 }
 
-func DumpType(t *ast.TypeSpec, fset *token.FileSet) map[string]interface{} {
-	var contained interface{} = nil
-	var typ string = ""
-
-	if res, ok := t.Type.(*ast.Ident); ok {
-		typ = "type-name"
-		contained = DumpIdent(res, fset)
-	}
-
-	if res, ok := t.Type.(*ast.ArrayType); ok {
-		typ = "array"
-		contained = DumpArray(res, fset)
-	}
-
-	if res, ok := t.Type.(*ast.MapType); ok {
-		typ = "map"
-		contained = map[string]interface{}{
-			"key":   DumpExpr(res.Key, fset),
-			"value": DumpExpr(res.Value, fset),
-		}
-	}
-
-	if res, ok := t.Type.(*ast.InterfaceType); ok {
-		typ = "interface"
-		contained = map[string]interface{}{
-			"methods":    DumpFields(res.Methods, fset),
-			"incomplete": res.Incomplete,
-		}
-	}
-
-	if res, ok := t.Type.(*ast.ChanType); ok {
-		typ = "chan"
-		contained = map[string]interface{}{
-			"direction": res.Dir,
-			"value":     DumpExpr(res.Value, fset),
-		}
-	}
-
-	if typ == "" {
-		pos := fset.PositionFor(t.Pos(), true).String()
-		panic("Unrecognized Type " + t.Name.Name + " in Type at " + pos)
-	}
-
+func DumpTypeAlias(t *ast.TypeSpec, fset *token.FileSet) map[string]interface{} {
 	return map[string]interface{}{
-		"kind":     "type",
-		"type":     typ,
+		"kind":     "decl",
+		"type":     "type-alias",
 		"name":     DumpIdent(t.Name, fset),
-		"value":    contained,
+		"value":    DumpExprAsType(t.Type, fset),
 		"comments": DumpCommentGroup(t.Comment, fset),
 	}
 }
@@ -541,7 +499,7 @@ func DumpGenDecl(decl *ast.GenDecl, fset *token.FileSet) interface{} {
 
 	case token.TYPE:
 		for i, v := range decl.Specs {
-			results[i] = DumpType(v.(*ast.TypeSpec), fset)
+			results[i] = DumpTypeAlias(v.(*ast.TypeSpec), fset)
 		}
 
 	case token.CONST:

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -40,6 +40,10 @@ func TestPackageFixtures(t *testing.T) {
 			"fixtures/packages/helloworld/helloworld.go",
 			"fixtures/packages/helloworld/helloworld.json",
 		},
+		Fixture{"simple type alias",
+			"fixtures/packages/simpletypealias/simpletypealias.go",
+			"fixtures/packages/simpletypealias/simpletypealias.json",
+		},
 	}
 
 	for _, fix := range fixtures {


### PR DESCRIPTION
DumpType was a legacy function from when I didn't understand that
TypeSpecs were used very rarely (only in top-level type alias
declarations). This rewrite uses DumpExprAsType and codifies the schema
for type aliases.