### PR TITLE
Fix parentheses contained in types. (#33)

### DIFF
--- a/fixtures/expressions/parenintype/paren.go.txt
+++ b/fixtures/expressions/parenintype/paren.go.txt
@@ -1,0 +1,1 @@
+[2](int)(beakman)

--- a/fixtures/expressions/parenintype/paren.json
+++ b/fixtures/expressions/parenintype/paren.json
@@ -1,0 +1,29 @@
+{
+    "coerced-to": {
+        "element": {
+            "kind": "type",
+            "type": "identifier",
+            "value": {
+                "kind": "ident",
+                "value": "int"
+            }
+        },
+        "kind": "type",
+        "length": {
+            "kind": "literal",
+            "type": "INT",
+            "value": "2"
+        },
+        "type": "array"
+    },
+    "kind": "expression",
+    "target": {
+        "kind": "expression",
+        "type": "identifier",
+        "value": {
+            "kind": "ident",
+            "value": "beakman"
+        }
+    },
+    "type": "cast"
+}

--- a/goblin.go
+++ b/goblin.go
@@ -64,6 +64,10 @@ func AttemptExprAsType(e ast.Expr, fset *token.FileSet) map[string]interface{} {
 		return nil
 	}
 
+	if n, ok := e.(*ast.ParenExpr); ok {
+		return AttemptExprAsType(n.X, fset)
+	}
+
 	if n, ok := e.(*ast.Ident); ok {
 		return map[string]interface{}{
 			"kind":  "type",

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -109,6 +109,11 @@ func TestExpressionFixtures(t *testing.T) {
 			"fixtures/expressions/chancast/chan.go.txt",
 			"fixtures/expressions/chancast/chan.json",
 		},
+		Fixture{
+			"cast with parenthesized type",
+			"fixtures/expressions/parenintype/paren.go.txt",
+			"fixtures/expressions/parenintype/paren.json",
+		},
 	}
 
 	for _, fix := range fixtures {


### PR DESCRIPTION
@joshbohde was hitting this when parsing `var memArray [512]([2]uint64)`. The fix is simple: just recurse inside.

Fixes #33.