### PR TITLE
Add new syntax node for method declarations.

### DIFF
--- a/fixtures/packages/methoddecl/method.go
+++ b/fixtures/packages/methoddecl/method.go
@@ -1,0 +1,15 @@
+package main
+
+type Thing struct {
+	count int8
+}
+
+func (t Thing) Inc() {
+	t.count += 1
+}
+
+func main() {
+	t := Thing { 1 }
+	t.Inc()
+	println(t.count)
+}

--- a/fixtures/packages/methoddecl/method.json
+++ b/fixtures/packages/methoddecl/method.json
@@ -1,0 +1,209 @@
+{
+  "all-comments": [],
+  "comments": [],
+  "declarations": [
+    [
+      {
+        "comments": [],
+        "kind": "decl",
+        "name": {
+          "kind": "ident",
+          "value": "Thing"
+        },
+        "type": "type-alias",
+        "value": {
+          "fields": [
+            {
+              "declared-type": {
+                "kind": "type",
+                "type": "identifier",
+                "value": {
+                  "kind": "ident",
+                  "value": "int8"
+                }
+              },
+              "kind": "field",
+              "names": [
+                {
+                  "kind": "ident",
+                  "value": "count"
+                }
+              ],
+              "tag": null
+            }
+          ],
+          "kind": "type",
+          "type": "struct"
+        }
+      }
+    ],
+    [
+      {
+        "body": [
+          {
+            "kind": "statement",
+            "left": [
+              {
+                "kind": "expression",
+                "qualifier": {
+                  "kind": "ident",
+                  "value": "t"
+                },
+                "type": "identifier",
+                "value": {
+                  "kind": "ident",
+                  "value": "count"
+                }
+              }
+            ],
+            "operator": "+",
+            "right": [
+              {
+                "kind": "literal",
+                "type": "INT",
+                "value": "1"
+              }
+            ],
+            "type": "assign-operator"
+          }
+        ],
+        "comments": [],
+        "kind": "decl",
+        "name": {
+          "kind": "ident",
+          "value": "Inc"
+        },
+        "params": [],
+        "reciever": {
+          "declared-type": {
+            "kind": "type",
+            "type": "identifier",
+            "value": {
+              "kind": "ident",
+              "value": "Thing"
+            }
+          },
+          "kind": "field",
+          "names": [
+            {
+              "kind": "ident",
+              "value": "t"
+            }
+          ],
+          "tag": null
+        },
+        "results": null,
+        "type": "method"
+      }
+    ],
+    [
+      {
+        "body": [
+          {
+            "kind": "statement",
+            "left": [
+              {
+                "kind": "expression",
+                "type": "identifier",
+                "value": {
+                  "kind": "ident",
+                  "value": "t"
+                }
+              }
+            ],
+            "right": [
+              {
+                "declared": {
+                  "kind": "type",
+                  "type": "identifier",
+                  "value": {
+                    "kind": "ident",
+                    "value": "Thing"
+                  }
+                },
+                "kind": "literal",
+                "type": "composite",
+                "values": [
+                  {
+                    "kind": "literal",
+                    "type": "INT",
+                    "value": "1"
+                  }
+                ]
+              }
+            ],
+            "type": "define"
+          },
+          {
+            "kind": "statement",
+            "type": "expression",
+            "value": {
+              "arguments": [],
+              "ellipsis": false,
+              "function": {
+                "kind": "expression",
+                "qualifier": {
+                  "kind": "ident",
+                  "value": "t"
+                },
+                "type": "identifier",
+                "value": {
+                  "kind": "ident",
+                  "value": "Inc"
+                }
+              },
+              "kind": "expression",
+              "type": "call"
+            }
+          },
+          {
+            "kind": "statement",
+            "type": "expression",
+            "value": {
+              "arguments": [
+                {
+                  "kind": "expression",
+                  "qualifier": {
+                    "kind": "ident",
+                    "value": "t"
+                  },
+                  "type": "identifier",
+                  "value": {
+                    "kind": "ident",
+                    "value": "count"
+                  }
+                }
+              ],
+              "ellipsis": false,
+              "function": {
+                "kind": "expression",
+                "type": "identifier",
+                "value": {
+                  "kind": "ident",
+                  "value": "println"
+                }
+              },
+              "kind": "expression",
+              "type": "call"
+            }
+          }
+        ],
+        "comments": [],
+        "kind": "decl",
+        "name": {
+          "kind": "ident",
+          "value": "main"
+        },
+        "params": [],
+        "results": null,
+        "type": "function"
+      }
+    ]
+  ],
+  "imports": [],
+  "kind": "file",
+  "name": {
+    "kind": "ident",
+    "value": "main"
+  }
+}

--- a/goblin.go
+++ b/goblin.go
@@ -814,13 +814,30 @@ func DumpFuncDecl(f *ast.FuncDecl, fset *token.FileSet) []interface{} {
 	}}
 }
 
+func DumpMethodDecl(f *ast.FuncDecl, fset *token.FileSet) []interface{} {
+	return []interface{}{map[string]interface{}{
+		"kind":     "decl",
+		"type":     "method",
+		"reciever": DumpField(f.Recv.List[0], fset),
+		"name":     DumpIdent(f.Name, fset),
+		"body":     DumpBlock(f.Body, fset),
+		"params":   DumpFields(f.Type.Params, fset),
+		"results":  DumpFields(f.Type.Results, fset),
+		"comments": DumpCommentGroup(f.Doc, fset),
+	}}
+}
+
 func DumpDecl(n ast.Decl, fset *token.FileSet) []interface{} {
 	if decl, ok := n.(*ast.GenDecl); ok {
 		return DumpGenDecl(decl, fset)
 	}
 
 	if decl, ok := n.(*ast.FuncDecl); ok {
-		return DumpFuncDecl(decl, fset)
+		if decl.Recv == nil {
+			return DumpFuncDecl(decl, fset)
+		} else {
+			return DumpMethodDecl(decl, fset)
+		}
 	}
 
 	if decl, ok := n.(*ast.BadDecl); ok {

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -61,6 +61,11 @@ func TestPackageFixtures(t *testing.T) {
 			"fixtures/packages/select/select.go",
 			"fixtures/packages/select/select.json",
 		},
+		Fixture{
+			"method declaration",
+			"fixtures/packages/methoddecl/method.go",
+			"fixtures/packages/methoddecl/method.json",
+		},
 	}
 
 	for _, fix := range fixtures {


### PR DESCRIPTION
The current code was parsing methods as function declarations (since
that's how they're encoded in the AST) and failing to dump information
about the reciever. This fixes that, adding a `"type": "method"` node to
the various declarations that can be returned.