### PR TITLE
Add 'type' tag for binary expressions.

### DIFF
--- a/fixtures/expressions/addition/addition.go.txt
+++ b/fixtures/expressions/addition/addition.go.txt
@@ -1,0 +1,1 @@
+ill + matic

--- a/fixtures/expressions/addition/addition.json
+++ b/fixtures/expressions/addition/addition.json
@@ -1,0 +1,21 @@
+{
+  "type": "expression",
+  "right": {
+    "value": {
+      "value": "matic",
+      "kind": "ident"
+    },
+    "type": "identifier",
+    "kind": "expression"
+  },
+  "operator": "+",
+  "left": {
+    "value": {
+      "value": "ill",
+      "kind": "ident"
+    },
+    "type": "identifier",
+    "kind": "expression"
+  },
+  "kind": "binary"
+}

--- a/goblin.go
+++ b/goblin.go
@@ -351,6 +351,7 @@ func DumpExprs(exprs []ast.Expr, fset *token.FileSet) []interface{} {
 
 func DumpBinaryExpr(b *ast.BinaryExpr, fset *token.FileSet) map[string]interface{} {
 	return map[string]interface{}{
+		"type":     "expression",
 		"kind":     "binary",
 		"left":     DumpExpr(b.X, fset),
 		"right":    DumpExpr(b.Y, fset),

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -119,6 +119,11 @@ func TestExpressionFixtures(t *testing.T) {
 			"fixtures/expressions/parenintype/paren.go.txt",
 			"fixtures/expressions/parenintype/paren.json",
 		},
+		Fixture{
+			"adding two identifiers",
+			"fixtures/expressions/addition/addition.go.txt",
+			"fixtures/expressions/addition/addition.json",
+		},
 	}
 
 	for _, fix := range fixtures {


### PR DESCRIPTION
I forgot to indicate that these are expression types. As a result, we
were failing downstream with missing `type` errors.