### PR TITLE
Add go fmt target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ LDFLAGS := -X 'main.version=$(VERSION)' \
            -X 'main.goversion=$(GOVERSION)'
 
 # development tasks
-test:
+fmt:
+	go fmt -x ./...
+
+test: fmt
 	go test -v $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
 
 PACKAGES := $(shell find ./* -type d | grep -v vendor)
@@ -36,3 +39,5 @@ TARGETS := $(patsubst cmd/%/main.go,%,$(CMD_SOURCES))
 
 %-${TRAVIS_TAG}-${TARGET}.tar.gz: %
 	tar czf $@ $<
+
+.PHONY: fmt

--- a/cmd/goblin/main.go
+++ b/cmd/goblin/main.go
@@ -1,11 +1,13 @@
 package main
 
-import ("encoding/json"
+import (
+	"encoding/json"
 	"flag"
 	"github.com/ReconfigureIO/goblin"
 	"go/parser"
-        "go/token"
-        "os")
+	"go/token"
+	"os"
+)
 
 // Assuming you build with `make`, this variable will be filled in automatically
 // (leaning on -ldflags -X).
@@ -13,15 +15,15 @@ var version string = "unspecified"
 
 func main() {
 	versionFlag := flag.Bool("v", false, "display goblin version")
-	fileFlag    := flag.String("file", "", "file to parse")
-	stmtFlag    := flag.String("stmt", "", "statement to parse")
-	exprFlag    := flag.String("expr", "", "expression to parse")
+	fileFlag := flag.String("file", "", "file to parse")
+	stmtFlag := flag.String("stmt", "", "statement to parse")
+	exprFlag := flag.String("expr", "", "expression to parse")
 
 	flag.Parse()
 	// Create the AST by parsing src.
 	fset := token.NewFileSet() // positions are relative to fset
 
-	if (*versionFlag) {
+	if *versionFlag {
 		println(version)
 		return
 	} else if *fileFlag != "" {

--- a/fixtures/packages/emptyfor/empty.go
+++ b/fixtures/packages/emptyfor/empty.go
@@ -2,6 +2,6 @@ package main
 
 func main() {
 	for {
-		
+
 	}
 }

--- a/fixtures/packages/helloworld/helloworld.go
+++ b/fixtures/packages/helloworld/helloworld.go
@@ -1,5 +1,5 @@
 package main
 
-func main()  {
+func main() {
 	println("Hello, world!")
 }

--- a/fixtures/packages/methoddecl/method.go
+++ b/fixtures/packages/methoddecl/method.go
@@ -9,7 +9,7 @@ func (t Thing) Inc() {
 }
 
 func main() {
-	t := Thing { 1 }
+	t := Thing{1}
 	t.Inc()
 	println(t.count)
 }


### PR DESCRIPTION
I have added the `fmt` target as a dependency of the `test` target as this suits a local development workflow well (i.e. add/change code -> `make test` => `go fmt && go test`) but I am not sure if this is ideal as that would mean that the Travis CI build will also run go fmt, but I will defer the decision to the maintainers.

The `fmt` target affects the `fixtures` directory and does change the formatting of the fixture files. I am assuming by the nature of the project (AST -> JSON) that the formatting shouldn't matter but thought it worth noting.