### PR TITLE
Add an appveyor config.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,4 +32,4 @@ build_script:
   - go build -o c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe github.com/ReconfigureIO/goblin/cmd/goblin
 
 artifacts:
-  - path: c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe
+  - path: build\goblin.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ test_script:
   - go test github.com/ReconfigureIO/goblin
 
 build_script:
-  - go build github.com/ReconfigureIO/goblin/cmd/goblin -o c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe
+  - go build -o c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe github.com/ReconfigureIO/goblin/cmd/goblin
 
 artifacts:
   - path: c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - set Path=c:\go\bin;c:\gopath\bin;C:\Program Files (x86)\Bazaar\
   - go version
   - go env
-  - ps: choco install make
+  - choco install make
 
 test_script:
   - make test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,15 +30,15 @@ test_script:
   - make test
 
 build_script:
-  - go build -ldflags  -o c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe github.com/ReconfigureIO/goblin/cmd/goblin
+  - make goblin
+  - rename goblin goblin.exe
 
 artifacts:
-  - path: build\goblin.exe
-    name: goblin.exe
+  - path: goblin.exe
 
 deploy:
   - provider: GitHub
-    artifact: build\goblin.exe
+    artifact: goblin.exe
     draft: false
     prerelease: false
     on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,3 +43,9 @@ deploy:
     on:
       branch: master                # release from master branch only
       appveyor_repo_tag: true       # deploy on tag push only
+
+notifications:
+  - provider: Slack
+    channel: #status
+    incoming_webhook:
+      secure: LbTv30cQKAAQHOmq90O6hFm1mjFRvZljYwtx7V00jq/HadB/IWPTwFzWFUOZMR6heHHMBxzGRmN8kRmqK5qw/q230fHqkJ4qZ+wUsiXz7VU=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,9 @@ deploy:
       appveyor_repo_tag: true       # deploy on tag push only
 
 notifications:
+  - provider: Email
+    on_build_success: false
+
   - provider: Slack
     channel: #status
     incoming_webhook:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+version: "{build}"
+
+platform: x64
+
+branches:
+  only:
+    - master
+
+# Source Config
+clone_folder: c:\gopath\src\github.com\ReconfigureIO\goblin
+
+environment:
+  GOPATH: c:\gopath
+  GOVERSION: 1.7.1
+
+init:
+  - git config --global core.autocrlf input
+
+install:
+  # Install the specific Go version.
+  - rmdir c:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.msi
+  - msiexec /i go%GOVERSION%.windows-amd64.msi /q
+  - set Path=c:\go\bin;c:\gopath\bin;C:\Program Files (x86)\Bazaar\
+  - go version
+  - go env
+
+test_script:
+  - go test github.com/ReconfigureIO/goblin
+
+build_script:
+  - go build github.com/ReconfigureIO/goblin/cmd/goblin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,4 +29,7 @@ test_script:
   - go test github.com/ReconfigureIO/goblin
 
 build_script:
-  - go build github.com/ReconfigureIO/goblin/cmd/goblin
+  - go build github.com/ReconfigureIO/goblin/cmd/goblin -O c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe
+
+artifacts:
+  - path: c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,12 +24,13 @@ install:
   - set Path=c:\go\bin;c:\gopath\bin;C:\Program Files (x86)\Bazaar\
   - go version
   - go env
+  - ps: choco install make
 
 test_script:
-  - go test github.com/ReconfigureIO/goblin
+  - make test
 
 build_script:
-  - go build -o c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe github.com/ReconfigureIO/goblin/cmd/goblin
+  - go build -ldflags  -o c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe github.com/ReconfigureIO/goblin/cmd/goblin
 
 artifacts:
   - path: build\goblin.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ test_script:
   - go test github.com/ReconfigureIO/goblin
 
 build_script:
-  - go build github.com/ReconfigureIO/goblin/cmd/goblin -O c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe
+  - go build github.com/ReconfigureIO/goblin/cmd/goblin -o c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe
 
 artifacts:
   - path: c:\gopath\src\github.com\ReconfigureIO\goblin\build\goblin.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - rmdir c:\go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.msi
   - msiexec /i go%GOVERSION%.windows-amd64.msi /q
-  - set Path=c:\go\bin;c:\gopath\bin;C:\Program Files (x86)\Bazaar\
+  - set Path=c:\go\bin;c:\gopath\bin;C:\Program Files (x86)\Bazaar\;%PATH%
   - go version
   - go env
   - choco install make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,3 +33,13 @@ build_script:
 
 artifacts:
   - path: build\goblin.exe
+    name: goblin.exe
+
+deploy:
+  - provider: GitHub
+    artifact: build\goblin.exe
+    draft: false
+    prerelease: false
+    on:
+      branch: master                # release from master branch only
+      appveyor_repo_tag: true       # deploy on tag push only


### PR DESCRIPTION
This adds auto deployment of artifacts for Windows (a `goblin.exe`) on tag to Github releases, just like we do with Linux. 

