### PR TITLE
Use Perish() on parse errors.

### DIFF
--- a/cmd/goblin/main.go
+++ b/cmd/goblin/main.go
@@ -36,11 +36,11 @@ func main() {
 	} else if *fileFlag != "" {
 		file, err := os.Open(*fileFlag)
 		if err != nil {
-			panic(err)
+			goblin.Perish(goblin.TOPLEVEL_POSITION, "path_error", err.Error())
 		}
 		info, err := file.Stat()
 		if err != nil {
-			panic(err)
+			goblin.Perish(goblin.TOPLEVEL_POSITION, "path_error", err.Error())
 		}
 
 		size := info.Size()
@@ -50,7 +50,7 @@ func main() {
 
 		f, err := parser.ParseFile(fset, *fileFlag, nil, parser.ParseComments)
 		if err != nil {
-			panic(err)
+			goblin.Perish(goblin.INVALID_POSITION, "positionless_syntax_error", err.Error())
 		}
 
 		if *builtinDumpFlag {

--- a/goblin.go
+++ b/goblin.go
@@ -39,7 +39,7 @@ func Perish(pos token.Position, typ string, reason string) {
 				"position": DumpPosition(pos),
 			},
 		})
-		os.Stdout.Write(res)
+		os.Stderr.Write(res)
 	}
 	os.Exit(1)
 }


### PR DESCRIPTION
Also ensures that erroneous output goes to stderr.