### PR TITLE
Add support for empty func definitions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ fmt:
 	go fmt -x ./...
 
 test: fmt
-	go test -v $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
+	go test -v $$(go list ./... | grep -v /vendor/ | grep -v /cmd/ | grep -v /fixtures/)
 
 PACKAGES := $(shell find ./* -type d | grep -v vendor)
 

--- a/fixtures/packages/emptyfunc/empty.go
+++ b/fixtures/packages/emptyfunc/empty.go
@@ -1,0 +1,6 @@
+package main
+
+func foo()
+
+func main() {
+}

--- a/fixtures/packages/emptyfunc/empty.json
+++ b/fixtures/packages/emptyfunc/empty.json
@@ -1,66 +1,66 @@
 {
-   "imports" : [],
    "kind" : "file",
+   "name" : {
+      "position" : {
+         "filename" : "fixtures/packages/emptyfunc/empty.go",
+         "offset" : 8,
+         "line" : 1,
+         "column" : 9
+      },
+      "value" : "main",
+      "kind" : "ident"
+   },
+   "imports" : [],
    "declarations" : [
       {
-         "results" : null,
-         "params" : [],
-         "body" : null,
-         "name" : {
-            "kind" : "ident",
-            "value" : "foo",
-            "position" : {
-               "line" : 3,
-               "filename" : "empty.go",
-               "offset" : 19,
-               "column" : 6
-            }
-         },
-         "comments" : [],
-         "position" : {
-            "column" : 1,
-            "offset" : 14,
-            "filename" : "empty.go",
-            "line" : 3
-         },
          "type" : "function",
-         "kind" : "decl"
+         "position" : {
+            "filename" : "fixtures/packages/emptyfunc/empty.go",
+            "column" : 1,
+            "line" : 3,
+            "offset" : 14
+         },
+         "body" : null,
+         "comments" : [],
+         "name" : {
+            "position" : {
+               "column" : 6,
+               "line" : 3,
+               "offset" : 19,
+               "filename" : "fixtures/packages/emptyfunc/empty.go"
+            },
+            "kind" : "ident",
+            "value" : "foo"
+         },
+         "params" : [],
+         "kind" : "decl",
+         "results" : null
       },
       {
-         "type" : "function",
-         "kind" : "decl",
-         "params" : [],
-         "body" : [],
-         "name" : {
-            "kind" : "ident",
-            "value" : "main",
-            "position" : {
-               "line" : 5,
-               "filename" : "empty.go",
-               "offset" : 31,
-               "column" : 6
-            }
-         },
          "comments" : [],
-         "position" : {
-            "line" : 5,
-            "offset" : 26,
-            "column" : 1,
-            "filename" : "empty.go"
+         "params" : [],
+         "kind" : "decl",
+         "name" : {
+            "position" : {
+               "filename" : "fixtures/packages/emptyfunc/empty.go",
+               "offset" : 31,
+               "line" : 5,
+               "column" : 6
+            },
+            "value" : "main",
+            "kind" : "ident"
          },
-         "results" : null
+         "results" : null,
+         "type" : "function",
+         "position" : {
+            "filename" : "fixtures/packages/emptyfunc/empty.go",
+            "column" : 1,
+            "line" : 5,
+            "offset" : 26
+         },
+         "body" : []
       }
    ],
-   "comments" : [],
    "all-comments" : [],
-   "name" : {
-      "value" : "main",
-      "kind" : "ident",
-      "position" : {
-         "line" : 1,
-         "column" : 9,
-         "offset" : 8,
-         "filename" : "empty.go"
-      }
-   }
+   "comments" : []
 }

--- a/fixtures/packages/emptyfunc/empty.json
+++ b/fixtures/packages/emptyfunc/empty.json
@@ -1,0 +1,66 @@
+{
+   "imports" : [],
+   "kind" : "file",
+   "declarations" : [
+      {
+         "results" : null,
+         "params" : [],
+         "body" : null,
+         "name" : {
+            "kind" : "ident",
+            "value" : "foo",
+            "position" : {
+               "line" : 3,
+               "filename" : "empty.go",
+               "offset" : 19,
+               "column" : 6
+            }
+         },
+         "comments" : [],
+         "position" : {
+            "column" : 1,
+            "offset" : 14,
+            "filename" : "empty.go",
+            "line" : 3
+         },
+         "type" : "function",
+         "kind" : "decl"
+      },
+      {
+         "type" : "function",
+         "kind" : "decl",
+         "params" : [],
+         "body" : [],
+         "name" : {
+            "kind" : "ident",
+            "value" : "main",
+            "position" : {
+               "line" : 5,
+               "filename" : "empty.go",
+               "offset" : 31,
+               "column" : 6
+            }
+         },
+         "comments" : [],
+         "position" : {
+            "line" : 5,
+            "offset" : 26,
+            "column" : 1,
+            "filename" : "empty.go"
+         },
+         "results" : null
+      }
+   ],
+   "comments" : [],
+   "all-comments" : [],
+   "name" : {
+      "value" : "main",
+      "kind" : "ident",
+      "position" : {
+         "line" : 1,
+         "column" : 9,
+         "offset" : 8,
+         "filename" : "empty.go"
+      }
+   }
+}

--- a/goblin.go
+++ b/goblin.go
@@ -905,6 +905,9 @@ func DumpStmt(s ast.Stmt, fset *token.FileSet) interface{} {
 }
 
 func DumpBlock(b *ast.BlockStmt, fset *token.FileSet) []interface{} {
+	if b == nil {
+		return nil
+	}
 	results := make([]interface{}, len(b.List))
 	for i, v := range b.List {
 		results[i] = DumpStmt(v, fset)

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -71,6 +71,11 @@ func TestPackageFixtures(t *testing.T) {
 			"fixtures/packages/interface_type/interface.go",
 			"fixtures/packages/interface_type/interface.json",
 		},
+		Fixture{
+			"empty function",
+			"fixtures/packages/emptyfunc/empty.go",
+			"fixtures/packages/emptyfunc/empty.json",
+		},
 	}
 
 	for _, fix := range fixtures {


### PR DESCRIPTION
From the [spec](https://golang.org/ref/spec#Function_declarations)

> A function declaration may omit the body. Such a declaration provides the signature for a function implemented outside Go, such as an assembly routine.

Right now, we crash on that example. This pull request fixes that crash, putting `null` in the output JSON.