### PR TITLE
Fix TypeAssert nil dereference bug

### DIFF
--- a/goblin.go
+++ b/goblin.go
@@ -294,16 +294,10 @@ func DumpExpr(e ast.Expr, fset *token.FileSet) map[string]interface{} {
 		// inner composites an implicit type:
 		// bool[][] { { false, true }, { true, false }}
 
-		var declared map[string]interface{} = nil
-
-		if n.Type != nil {
-			declared = DumpExprAsType(n.Type, fset)
-		}
-
 		return map[string]interface{}{
 			"kind":     "literal",
 			"type":     "composite",
-			"declared": declared,
+			"declared": AttemptExprAsType(n.Type, fset),
 			"values":   DumpExprs(n.Elts, fset),
 			"position": DumpPosition(fset.Position(e.Pos())),
 		}
@@ -375,7 +369,7 @@ func DumpExpr(e ast.Expr, fset *token.FileSet) map[string]interface{} {
 			"kind":     "expression",
 			"type":     "type-assert",
 			"target":   DumpExpr(n.X, fset),
-			"asserted": DumpExprAsType(n.Type, fset),
+			"asserted": AttemptExprAsType(n.Type, fset),
 			"position": DumpPosition(fset.Position(e.Pos())),
 		}
 	}


### PR DESCRIPTION
The following is a valid Go program that will cause goblin to segfault:
```Go
package bug
func f(x interface{}) {
	switch x.(type) {}
}
```

It happens because a TypeAssertExpr's Type field may be nil ([spec](https://golang.org/pkg/go/ast/#TypeAssertExpr)). This PR fixes the issue by replacing the use of 'DumpExprAsType' with 'AttemptExprAsType' for this field.